### PR TITLE
!!! Feature: php 8.1 safe

### DIFF
--- a/Classes/Profile/CheckAllLinks.php
+++ b/Classes/Profile/CheckAllLinks.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CodeQ\LinkChecker\Profile;
 
-use Spatie\Crawler\CrawlAllUrls;
+use Spatie\Crawler\CrawlProfiles\CrawlAllUrls;
 
 class CheckAllLinks extends CrawlAllUrls
 {

--- a/Classes/Reporter/BaseReporter.php
+++ b/Classes/Reporter/BaseReporter.php
@@ -10,10 +10,10 @@ use CodeQ\LinkChecker\Service\UriService;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\ConsoleOutput;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
-use Spatie\Crawler\CrawlObserver;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Exception\RequestException;
+use Spatie\Crawler\CrawlObservers\CrawlObserver;
 
 abstract class BaseReporter extends CrawlObserver
 {

--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,13 @@
     "type": "neos-package",
     "license": "GPL-3.0-or-later",
     "require": {
+        "php": "^7.4 || ^8.0",
         "league/csv": "^9.1",
         "neos/neos": "^4.3 || 5 - 8 || dev-master",
         "neos/swiftmailer": "^7.3.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "sitegeist/fusionlinkprototypes": "^1.0",
-        "spatie/crawler": "^4.1",
+        "spatie/crawler": "^6.0",
         "symfony/polyfill-php80": "^1.16"
     },
     "autoload": {


### PR DESCRIPTION
update the library `spatie/crawler` to v6 since its dependency in the v4 `tightenco/collect` doesnt work with php8.1 in the required version.

requires us to use at least php 7.4 so this is a breaking change, as we don't support php 7.1 - 7.3 anymore