### PR TITLE
Remove redundant symfony/polyfill-php80 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         "neos/swiftmailer": "^7.3.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "sitegeist/fusionlinkprototypes": "^1.0",
-        "spatie/crawler": "^8.0",
-        "symfony/polyfill-php80": "^1.16"
+        "spatie/crawler": "^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This package depends on `symfony/polyfill-php80`, but also `php: ^8.1`, so the polyfill requirement doesn't seem necessary anymore?